### PR TITLE
Update roblox-bat to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@alexop/openapi-zod-client": "^1.10.2",
     "p-limit": "^3.0.0",
-    "roblox-bat": "^0.1.1",
+    "roblox-bat": "^0.1.3",
     "zod": "^3.21.4"
   },
   "repository": {


### PR DESCRIPTION
`data-is-bound-auth-token` was interpreted as being enabled at all in <0.1.2. It is actually whether it is enabled on **all** urls, whitelist bypasses it