### PR TITLE
Add type EndpointGeneric to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export type EndpointSchema = EndpointBase & {
  * This is a hack to allow us to show the parameters and response types of an endpoint
  * as the inferred types of the parameters and response properties.
  */
-type EndpointGeneric<T, U, E> = EndpointBase & {
+export type EndpointGeneric<T, U, E> = EndpointBase & {
   parameters?: T;
   body?: E;
   response: U;


### PR DESCRIPTION
Currently only `EndpointSchema` is exposed from the module, which types all parameters as `any`.

Exporting the `EndpointGeneric` type allows tom-foolery like this

```ts
function roproxify<T, U, V>(inputEndpoint: EndpointGeneric<T, U, V>): EndpointGeneric<T, U, V> {
  return {
    ...inputEndpoint,
    baseUrl: inputEndpoint.baseUrl.replace('roblox', 'roproxy'),
  }
}

const groupWallPagesIterable = fetchApiPagesGenerator(roproxify(getGroupsGroupidWallPosts), { groupId: 12345678 })
```

to work without losing type-safety.